### PR TITLE
LAN: Add LAN tab allowing to use the limited local TCP API of Venus E…

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1108,3 +1108,201 @@
 .hex-parser-result {
     margin-top: 15px;
 }
+
+/* ============================================================
+   BLE explainer banner (Read tab)
+   ============================================================ */
+
+.ble-explainer {
+    background: #eef2ff;
+    border-left: 3px solid #667eea;
+    border-radius: 0 4px 4px 0;
+    padding: 10px 14px;
+    margin: 0 0 14px 0;
+    font-size: 13px;
+    color: #3d3d5c;
+    line-height: 1.55;
+}
+
+.lan-explainer {
+    background: #eefaf3;
+    border-left-color: #28a745;
+    color: #1d4a2a;
+}
+
+.lan-explainer a          { color: #1a7a3a; }
+.lan-explainer a:hover    { color: #145c2b; }
+
+.ble-explainer code {
+    background: #dde3f8;
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 12px;
+}
+
+/* ============================================================
+   LAN Monitor Tab
+   ============================================================ */
+
+.lan-section {
+    padding: 10px 0;
+}
+
+.lan-config-block {
+    background: #f8f9fa;
+    border: 1px solid #dee2e6;
+    border-radius: 6px;
+    padding: 14px 16px;
+    margin-bottom: 12px;
+}
+
+.lan-config-block h4 {
+    margin: 0 0 10px 0;
+    font-size: 14px;
+    color: #495057;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.lan-code {
+    background: #282c34;
+    color: #abb2bf;
+    border-radius: 4px;
+    padding: 8px 12px;
+    font-size: 13px;
+    font-family: 'Courier New', monospace;
+    margin: 0 0 10px 0;
+    user-select: all;
+}
+
+.lan-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+}
+
+.lan-input {
+    padding: 7px 10px;
+    border: 1px solid #ced4da;
+    border-radius: 4px;
+    font-size: 13px;
+    flex: 1;
+    min-width: 140px;
+    background: #fff;
+    color: #333;
+}
+
+.lan-input-port  { flex: 0 0 90px;  min-width: 90px; }
+.lan-input-tiny  { flex: 0 0 55px;  min-width: 55px; padding: 3px 6px; }
+
+.lan-btn {
+    padding: 7px 14px;
+    font-size: 13px;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    white-space: nowrap;
+    flex-shrink: 0;
+    transition: opacity 0.15s;
+}
+
+.lan-btn:hover   { opacity: 0.88; transform: none; }
+.lan-btn:disabled { background: #adb5bd; cursor: not-allowed; }
+
+.lan-mode-row { margin-top: 8px; }
+.lan-mode-btn {
+    padding: 5px 12px;
+    font-size: 12px;
+}
+
+.lan-bridge-status {
+    margin-top: 8px;
+    font-size: 13px;
+    font-weight: 500;
+    padding: 4px 8px;
+    border-radius: 3px;
+}
+
+.lan-status-connecting  { background: #fff3cd; color: #856404; }
+.lan-status-connected   { background: #d4edda; color: #155724; }
+.lan-status-disconnected { background: #f8d7da; color: #721c24; }
+
+.lan-hint {
+    color: #6c757d;
+    font-size: 12px;
+    margin: 4px 0 0 0;
+    font-style: italic;
+}
+
+.lan-device-list {
+    margin-bottom: 12px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.lan-device-card {
+    background: #fff;
+    border: 2px solid #dee2e6;
+    border-radius: 6px;
+    padding: 10px 12px;
+    cursor: pointer;
+    min-width: 180px;
+    transition: border-color 0.15s;
+    position: relative;
+}
+
+.lan-device-card:hover   { border-color: #764ba2; }
+.lan-device-active       { border-color: #667eea !important; background: #f0f0ff; }
+
+.lan-device-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 4px;
+}
+
+.lan-device-name     { font-weight: 600; font-size: 14px; color: #333; }
+.lan-device-autoname { font-weight: 400; font-size: 12px; color: #888; margin-left: 6px; }
+.lan-device-detail { font-size: 12px; color: #6c757d; }
+
+.lan-remove-btn {
+    background: none;
+    border: none;
+    color: #adb5bd;
+    font-size: 14px;
+    cursor: pointer;
+    padding: 0 2px;
+    line-height: 1;
+    flex-shrink: 0;
+}
+
+.lan-remove-btn:hover { color: #dc3545; transform: none; }
+
+.lan-poll-label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    flex-wrap: wrap;
+}
+
+.lan-data-display {
+    margin-top: 4px;
+}
+
+.lan-data-display h3 {
+    margin: 0 0 10px 0;
+    color: #343a40;
+}
+
+.lan-data-display h4 {
+    margin: 16px 0 6px 0;
+    font-size: 14px;
+    color: #495057;
+    border-bottom: 1px solid #dee2e6;
+    padding-bottom: 4px;
+}

--- a/index.html
+++ b/index.html
@@ -135,8 +135,9 @@
                     <button class="command-tab-button" onclick="switchCommandTab('network')">🕰 Network</button>
                     <button class="command-tab-button" onclick="switchCommandTab('advanced')">🔧 Advanced</button>
                     <button class="command-tab-button" onclick="switchCommandTab('ota')">🔥 OTA</button>
+                    <button class="command-tab-button" onclick="switchCommandTab('lan')">🌐 LAN</button>
                 </div>
-                
+
                 <!-- Command Tab Contents (Loaded Dynamically) -->
                 <div id="readTab" class="command-tab active"></div>
                 <div id="powerTab" class="command-tab"></div>
@@ -145,6 +146,7 @@
                 <div id="networkTab" class="command-tab"></div>
                 <div id="advancedTab" class="command-tab"></div>
                 <div id="otaTab" class="command-tab"></div>
+                <div id="lanTab" class="command-tab"></div>
             </div>
 
 
@@ -187,6 +189,8 @@
     <script src="js/response-handler.js"></script>
     <script src="js/ble-protocol.js"></script>
     <script src="js/ui-controller.js"></script>
+    <script src="js/lan-transport.js"></script>
+    <script src="js/lan-monitor.js"></script>
     <script type="module">
         // Import the new payload system from compiled output
         import { createPayload } from './js/dist/protocol/payloads/index.js';

--- a/js/ble-protocol.js
+++ b/js/ble-protocol.js
@@ -961,7 +961,15 @@ async function sendCommandWithRetry(commandType, commandName, payload = null, op
  */
 async function sendCommand(commandType, commandName, payload = null, retryCount = 0) {
     if (!(window.uiController ? window.uiController.isConnected() : false)) return;
-    
+
+    // isConnected() is true for both BLE and LAN. BLE commands require an actual
+    // BLE server connection — try a LAN fallback first, then warn if none exists.
+    if (!server?.connected) {
+        if (await (window.lanFallbackCommand?.(commandType) ?? false)) return;
+        log('⚠️ This command requires a BLE connection. Use the 🌐 LAN tab to interact with network-connected devices.');
+        return;
+    }
+
     // Block commands during OTA
     if (otaInProgress) {
         log('⚠️ Command blocked: OTA update in progress');
@@ -2481,6 +2489,11 @@ async function runAllTests() {
 async function readDeviceIdentifiers() {
     if (!(window.uiController ? window.uiController.isConnected() : false)) {
         log('❌ Not connected to device');
+        return;
+    }
+    if (!server?.connected) {
+        if (await (window.lanFallbackDeviceIds?.() ?? false)) return;
+        log('⚠️ Device IDs (VID/GID/XID) require a BLE connection.');
         return;
     }
 

--- a/js/ui-controller.js
+++ b/js/ui-controller.js
@@ -9,6 +9,7 @@
 // ==========================================
 
 let isConnected = false;
+let isLanConnected = false;
 let deviceType = 'unknown'; // 'battery', 'meter', or 'unknown'
 
 // ==========================================
@@ -126,6 +127,27 @@ function updateStatus(connected, deviceName = null) {
     updateButtonStates(connected);
     
     isConnected = connected;
+}
+
+/**
+ * Called by lan-monitor.js when LAN devices are added/removed.
+ * Updates the global status bar and button states without touching the
+ * BLE connect/disconnect buttons (those remain BLE-only).
+ */
+function updateLanStatus(connected, deviceName = null) {
+    isLanConnected = connected;
+
+    // Only paint the status bar if BLE isn't already holding it.
+    if (!isConnected) {
+        const statusEl = document.getElementById('status');
+        if (statusEl) {
+            statusEl.textContent = connected
+                ? `LAN${deviceName ? ': ' + deviceName : ''}`
+                : 'Disconnected';
+            statusEl.className = connected ? 'connected' : 'disconnected';
+        }
+        updateButtonStates(connected);
+    }
 }
 
 // ==========================================
@@ -736,7 +758,9 @@ window.uiController = {
     formatHexDump,
     updateOTAProgress,
     clearAll,
-    isConnected: () => isConnected,
+    isConnected: () => isConnected || isLanConnected,
+    isBleConnected: () => isConnected,
+    updateLanStatus,
     setDeviceType: (type) => { deviceType = type; },
     getDeviceType: () => deviceType
 };

--- a/templates/development-commands.html
+++ b/templates/development-commands.html
@@ -1,3 +1,6 @@
+<div class="ble-explainer">
+    <strong>Bluetooth (BLE) required</strong> — these development and diagnostic commands are sent over Bluetooth Low Energy using proprietary binary frames. They have no equivalent in the LAN Open API. Click <strong>Connect to Marstek</strong> at the top of the page to establish a BLE connection first.
+</div>
 <div class="section-caption">
     ⚠️ <strong>Advanced:</strong> These commands are for development and diagnostics. Use with caution.
 </div>

--- a/templates/lan-commands.html
+++ b/templates/lan-commands.html
@@ -1,0 +1,79 @@
+<!-- LAN Monitor Tab -->
+<div class="lan-section">
+
+  <!-- LAN explainer -->
+  <div class="ble-explainer lan-explainer">
+    <strong>Local Network (LAN) mode</strong> — communicates with your Marstek battery over your home WiFi using the device's built-in <em>Open API</em> (UDP JSON-RPC, default port 30000). This works from anywhere on the same network, with no Bluetooth required and no range limit. Because browsers cannot send raw UDP packets, a small local bridge script must be running on this computer (step 1 below).<br><br>
+    <strong>Limitations:</strong> the Open API exposes a smaller set of data than BLE — energy totals, battery state, solar input, WiFi status, and operating mode. Detailed diagnostics (BMS cell voltages, error logs, event history, firmware update) are only available over Bluetooth. The Local API must first be enabled on the device via the Marstek app or using BLE command 0x28 from this tool.<br><br>
+    Full command reference: <a href="https://static-eu.marstekcloud.com/ems/resource/agreement/MarstekDeviceOpenApi.pdf" target="_blank" rel="noopener">Marstek Device Open API (PDF)</a>.
+  </div>
+
+  <!-- Bridge Connection -->
+  <div class="lan-config-block">
+    <h4>1. Start the local UDP bridge</h4>
+    <pre class="lan-code">cd proxy &amp;&amp; npm install &amp;&amp; node udp-bridge.js</pre>
+    <div class="lan-row">
+      <input type="text" id="lanProxyUrl" value="ws://localhost:3001" placeholder="ws://localhost:3001" class="lan-input" />
+      <button onclick="lanConnectBridge()" class="btn-connect lan-btn">Connect</button>
+      <button onclick="lanDisconnectBridge()" class="lan-btn">Disconnect</button>
+    </div>
+    <div id="lanBridgeStatus" class="lan-bridge-status lan-status-disconnected">Not connected</div>
+  </div>
+
+  <!-- Device Entry -->
+  <div class="lan-config-block">
+    <h4>2. Add device(s)</h4>
+    <div class="lan-row">
+      <input type="text"   id="lanDeviceName" placeholder="My Battery (optional label)" class="lan-input" />
+      <input type="text"   id="lanDeviceIp"   placeholder="192.168.1.100" class="lan-input" />
+      <input type="number" id="lanDevicePort"  value="30000" min="1" max="65535" class="lan-input lan-input-port" />
+      <button onclick="lanAddDevice()" class="lan-btn">Add</button>
+      <button onclick="lanDiscoverDevices()" class="lan-btn" id="lanDiscoverBtn">🔍 Discover</button>
+    </div>
+    <p class="lan-hint">Label is optional — used as the display name. Port is set in the Marstek app when enabling the local API (default 30000).</p>
+  </div>
+
+  <!-- Device List -->
+  <div id="lanDeviceList" class="lan-device-list">
+    <p class="lan-hint">No devices yet. Add an IP or use Discover.</p>
+  </div>
+
+  <!-- Commands -->
+  <div class="lan-config-block">
+    <h4>3. Commands</h4>
+    <div class="command-grid">
+      <button onclick="lanGetFullStatus()"           class="cmd-btn">📊 Full Status</button>
+      <button onclick="lanSendCommand('ES.GetStatus')" class="cmd-btn">⚡ Energy System</button>
+      <button onclick="lanSendCommand('Bat.GetStatus')" class="cmd-btn">🔋 Battery</button>
+      <button onclick="lanSendCommand('PV.GetStatus')" class="cmd-btn">☀️ Solar (PV)</button>
+      <button onclick="lanSendCommand('Wifi.GetStatus')" class="cmd-btn">📶 WiFi</button>
+      <button onclick="lanSendCommand('BLE.GetStatus')" class="cmd-btn">📡 BLE Status</button>
+      <button onclick="lanSendCommand('ES.GetMode')"  class="cmd-btn">⚙️ Get Mode</button>
+      <button onclick="lanSendCommand('Marstek.GetDevice', {ble_mac:'0'})" class="cmd-btn">ℹ️ Device Info</button>
+    </div>
+
+    <!-- Mode control -->
+    <div class="lan-row lan-mode-row">
+      <label><strong>Set mode:</strong></label>
+      <button onclick="lanSetMode('Auto')"    class="lan-btn lan-mode-btn">Auto</button>
+      <button onclick="lanSetMode('AI')"      class="lan-btn lan-mode-btn">AI</button>
+      <button onclick="lanSetMode('Manual')"  class="lan-btn lan-mode-btn">Manual</button>
+      <button onclick="lanSetMode('Passive')" class="lan-btn lan-mode-btn">Passive</button>
+    </div>
+  </div>
+
+  <!-- Auto-poll -->
+  <div class="lan-config-block">
+    <label class="lan-poll-label">
+      <input type="checkbox" id="lanAutoPoll" onchange="lanToggleAutoPoll(this.checked)" />
+      Auto-poll ES + Battery every
+      <input type="number" id="lanPollInterval" value="5" min="1" max="300" class="lan-input lan-input-tiny" />
+      seconds
+    </label>
+  </div>
+
+  <!-- Data display area -->
+  <div id="lanDataDisplay" class="lan-data-display"></div>
+
+</div>
+<script>if (window.lanInitTab) lanInitTab();</script>

--- a/templates/network-commands.html
+++ b/templates/network-commands.html
@@ -1,3 +1,6 @@
+<div class="ble-explainer">
+    <strong>Bluetooth (BLE) required</strong> — these commands synchronise the device clock and write network IP configuration over Bluetooth Low Energy. They have no equivalent in the LAN Open API. Click <strong>Connect to Marstek</strong> at the top of the page to establish a BLE connection first.
+</div>
 <div class="section-caption">
     ⚠️ <strong>Time & Network:</strong> These commands update device clock and network configuration. IP changes may affect remote monitoring.
 </div>

--- a/templates/ota-commands.html
+++ b/templates/ota-commands.html
@@ -1,3 +1,6 @@
+<div class="ble-explainer">
+    <strong>Bluetooth (BLE) required</strong> — OTA firmware updates transfer a binary <code>.bin</code> file directly to the device over Bluetooth Low Energy in 132-byte chunks. This cannot be performed via the LAN Open API. Click <strong>Connect to Marstek</strong> at the top of the page to establish a BLE connection first.
+</div>
 <div class="section-caption" style="background: #721c24; color: white; border-left-color: #f5c6cb;">
     ⚠️ <strong>EXTREME DANGER:</strong> OTA firmware updates can permanently brick your device! Only use if you have a backup and recovery method. This is reverse-engineered and experimental.
 </div>

--- a/templates/power-commands.html
+++ b/templates/power-commands.html
@@ -1,3 +1,6 @@
+<div class="ble-explainer">
+    <strong>Bluetooth (BLE) required</strong> — these commands write power-limit settings directly to the device over Bluetooth Low Energy. They have no equivalent in the LAN Open API; there is no LAN command to set watt limits. Click <strong>Connect to Marstek</strong> at the top of the page to establish a BLE connection first.
+</div>
 <div class="section-caption">
     ⚠️ <strong>Power Settings:</strong> These commands modify power output limits and operating modes. Changes take effect immediately and may affect connected loads.
 </div>

--- a/templates/read-commands.html
+++ b/templates/read-commands.html
@@ -1,6 +1,9 @@
 <div class="section-caption">
     📖 <strong>Read Commands:</strong> These commands safely read information from your device including power status, battery data, network configuration, and system logs. No settings are modified.
 </div>
+<div class="ble-explainer">
+    <strong>Bluetooth (BLE)</strong> — these commands communicate directly with the battery over <em>Bluetooth Low Energy</em>, the same short-range radio your phone uses to pair with headphones or a smartwatch. The battery must be within ~10 m of this computer and not already connected to another device (phone, tablet). Click <strong>Connect to Marstek</strong> above, choose your <code>MST_ACCP_…</code> device from the browser picker, and the buttons below will activate. If your battery is on your WiFi network instead, use the <strong>🌐 LAN tab</strong> to reach it over the local network without Bluetooth.
+</div>
 <div class="command-grid">
     <button onclick="sendCommand(0x03, 'Runtime Info')" disabled data-tooltip="Real-time power flow, temperatures, and system status" class="cmd-button" data-requires-connection="true">
         <span class="cmd-button-text">⚡ Runtime Info</span>

--- a/templates/system-commands.html
+++ b/templates/system-commands.html
@@ -1,3 +1,6 @@
+<div class="ble-explainer">
+    <strong>Bluetooth (BLE) required</strong> — these commands modify system settings (EPS mode, operating mode, CT configuration, BLE lock) by writing to the device over Bluetooth Low Energy. Most have no equivalent in the LAN Open API. Note: the <em>Enable Local API</em> buttons themselves require a BLE connection to work — the LAN tab can only be used once the Local API has already been enabled on the device.
+</div>
 <div class="section-caption">
     ⚠️ <strong>System Settings:</strong> These commands change operational modes including EPS (Emergency Power Supply), AC input behavior, and generator control. Settings persist after power cycle.
 </div>


### PR DESCRIPTION
… batteries + fallback from BLE to LAN for some existing actions

This extension works but has been vibe-coded (not my programming language) with little verification. Hopefully, this is still useful and secure as it is supposed to work on a local network, only when the local API is enabled on the batteries.

I have a setup with 3 Venus E 3.0 and it works relatively well in that case. It detects all 3 batteries, gets some info and generally seems to work.